### PR TITLE
app: boards: add support for sample application on nRF9160 DK

### DIFF
--- a/app/boards/nrf9160dk_nrf9160.overlay
+++ b/app/boards/nrf9160dk_nrf9160.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Natalia Pluta
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	example_sensor: example-sensor {
+		compatible = "zephyr,example-sensor";
+		input-gpios = <&gpio0 11 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+	};
+
+	blink_led: blink-led {
+		compatible = "blink-gpio-led";
+		led-gpios = <&gpio0 5 GPIO_ACTIVE_HIGH>; // Green LED 4 on the nRF9160 DK
+		blink-period-ms = <1000>;
+	};
+};

--- a/app/sample.yaml
+++ b/app/sample.yaml
@@ -10,6 +10,7 @@ common:
   integration_platforms:
     - custom_plank
     - nrf54l15dk/nrf54l15/cpuapp
+    - nrf9160dk/nrf9160
 tests:
   app.default: {}
   app.debug:


### PR DESCRIPTION
Added device tree overlay to support a sample application on the nRF9160 DK.
This includes defining an example sensor and a blink LED. Updated sample.yaml
to include nRF9160 DK in the integration platforms for testing purposes.

Closes: #1

Signed-off-by: Natalia Pluta <pluta.natalia.m@gmail.com>

Output of sample application running on nRF9160 DK:
```
*** Booting My Application v1.0.0-311ba547b108 ***
*** Using nRF Connect SDK v2.9.99-b820eaf478f3 ***
*** Using Zephyr OS v4.0.99-c9113a87822e ***
Zephyr Example Application 1.0.0
Use the sensor to change LED blinking period
Proximity detected, setting LED period to 900 ms
Proximity detected, setting LED period to 800 ms
Proximity detected, setting LED period to 700 ms
```